### PR TITLE
fix(plugin): added better plugin support by dropping --clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ jobs:
 ```
 
 
+## Plugin Authors
+To make sure Neovim can see your health.lua file, make sure to add your plugin to the `:help runtimepath`.
+
+An example,
+[nvim-best-practices-plugin-template](https://github.com/ColinKennedy/nvim-best-practices-plugin-template/blob/main/.github/workflows/checkhealth.yml),
+shows that you can modify the `nvim` executable to `nvim -u minimal_init.lua` and
+provide any plugin-setup-logic there before this action gets called.
+
+
 ## Advanced Usage
 You can customize the `:checkhealth` command:
 
@@ -62,8 +71,10 @@ You can customize the `:checkhealth` command:
 It's common to override `checks` if you are writing a Neovim plugin that supports
 `:checkhealth`.
 
-But most of the time, you will want to keep the default values of `executable` and
-`severity`.
+If you're writing a plugin you probably will want to update `executable`. For an example,
+see [nvim-best-practices-plugin-template](https://github.com/ColinKennedy/nvim-best-practices-plugin-template/blob/main/.github/workflows/checkhealth.yml).
+
+And rarely does anyone want to check the default for `severity`.
 
 
 ## Settings

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
         TERM: xterm-256color
 
         # NOTE: This environment variable is for readability / convenience
-        GITHUB_NEOVIM_CHECKHEALTH_COMMAND: ${{ inputs.executable }} --clean --headless -l $GITHUB_ACTION_PATH/main.lua "${{ inputs.checks }}" ${{ inputs.minimum_severity }}
+        GITHUB_NEOVIM_CHECKHEALTH_COMMAND: ${{ inputs.executable }} --headless -l $GITHUB_ACTION_PATH/main.lua "${{ inputs.checks }}" ${{ inputs.minimum_severity }}
       with:
         linux: |
           ${{ env.GITHUB_NEOVIM_CHECKHEALTH_COMMAND }}

--- a/main.lua
+++ b/main.lua
@@ -96,7 +96,7 @@ local function main()
 
     if not minimum or severity >= minimum then
         exit_code = severity
-        print(string.format('Found error "%s" using code "%s".', _Code[exit_code], exit_code))
+        print(string.format('Found error "%s" using code "%s".', _Code[tostring(exit_code)], exit_code))
     end
 
     vim.cmd(string.format("cquit %s", exit_code))


### PR DESCRIPTION
Two changes:

- `--clean` was interfering with a Neovim plugin's ability to provide setup instructions
- An existing error message was reporting `nil`. Now it should print properly.

